### PR TITLE
Add a CI job that tests against pinned requirements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/packaging/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           python-version: '${{ matrix.python_version }}'
       - name: install the package
-        run: python3 -m pip install .[test]
+        run: python3 -m pip install uv && uv pip install .[test]
       - name: run pytest
         run: pytest --cov=microscope_calibration --cov-report=xml --cov-report=term tests/
       - name: submit code coverage
@@ -47,7 +47,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: install the package
-        run: python3 -m pip install .[test] -r packaging/requirements.txt
+        run: python3 -m pip install uv && uv pip install .[test] -r packaging/requirements.txt
       - name: run pytest
         run: pytest --cov=microscope_calibration --cov-report=xml --cov-report=term tests/
 
@@ -60,7 +60,7 @@ jobs:
         with:
           python-version: '3.12'
       - name: install the package
-        run: python3 -m pip install .[test]
+        run: python3 -m pip install uv && uv pip install .[test]
       - name: run pytest
         run: NUMBA_DISABLE_JIT=1 pytest --cov=microscope_calibration --cov-report=xml --cov-report=term tests/
       - name: submit code coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,19 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  pinned-requirements:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Choose Python version ${{ matrix.python_version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: install the package
+        run: python3 -m pip install .[test] -r packaging/requirements.txt
+      - name: run pytest
+        run: pytest --cov=microscope_calibration --cov-report=xml --cov-report=term tests/
+
   numba_coverage:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           python-version: '${{ matrix.python_version }}'
       - name: install the package
-        run: python3 -m pip install uv && uv pip install .[test]
+        run: python3 -m pip install uv && uv pip install --system .[test]
       - name: run pytest
         run: pytest --cov=microscope_calibration --cov-report=xml --cov-report=term tests/
       - name: submit code coverage
@@ -47,7 +47,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: install the package
-        run: python3 -m pip install uv && uv pip install .[test] -r packaging/requirements.txt
+        run: python3 -m pip install uv && uv pip install --system .[test] -r packaging/requirements.txt
       - name: run pytest
         run: pytest --cov=microscope_calibration --cov-report=xml --cov-report=term tests/
 
@@ -60,7 +60,7 @@ jobs:
         with:
           python-version: '3.12'
       - name: install the package
-        run: python3 -m pip install uv && uv pip install .[test]
+        run: python3 -m pip install uv && uv pip install --system .[test]
       - name: run pytest
         run: NUMBA_DISABLE_JIT=1 pytest --cov=microscope_calibration --cov-report=xml --cov-report=term tests/
       - name: submit code coverage

--- a/packaging/requirements.txt
+++ b/packaging/requirements.txt
@@ -440,7 +440,7 @@ tblib==3.0.0
     # via
     #   distributed
     #   libertem
-temgymbasic @ git+https://github.com/TemGym/TemGym@cf07c2bb059f767e5a273e8c4bbaa19e94cfd459
+temgymbasic @ git+https://github.com/TemGym/TemGym@03062b098a50ea72f0ae9a2438b861d7a62691ee
 terminado==0.18.0
     # via
     #   jupyter-server

--- a/packaging/requirements.txt
+++ b/packaging/requirements.txt
@@ -440,7 +440,7 @@ tblib==3.0.0
     # via
     #   distributed
     #   libertem
-temgymbasic @ git+https://github.com/TemGym/TemGym@03062b098a50ea72f0ae9a2438b861d7a62691ee
+temgymbasic @ git+https://github.com/TemGym/TemGym@c7a851ce2d6719acc47d36d31d91df27b1e9590b
 terminado==0.18.0
     # via
     #   jupyter-server

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "numpy",
     "libertem",
     "typing-extensions",
-    "temgymbasic@git+https://github.com/TemGym/TemGym@03062b098a50ea72f0ae9a2438b861d7a62691ee",
+    "temgymbasic@git+https://github.com/TemGym/TemGym@c7a851ce2d6719acc47d36d31d91df27b1e9590b",
     "numba",
     "scikit-image",
     "scipy",


### PR DESCRIPTION
Needs https://github.com/TemGym/TemGym/pull/35 for a clean CI run :heavy_check_mark: 

As these requirements are the ones that end up in the docker container image, we should make updating the requirements testable. The installation tries to mimick what's done in the container build script as far as possible, but as it needs to install the `[test]` extra, it can't use `--no-deps` and thus isn't a 100% match.

Also fix incorrect git sha in the pinned requirements - it has to match the `pyproject.toml`!

Switch to `uv` for much faster CI run.